### PR TITLE
Add scope as "test" for pool-registry dependency as Pool registry cla…

### DIFF
--- a/staker-registry/pom.xml
+++ b/staker-registry/pom.xml
@@ -22,6 +22,7 @@
             <groupId>org.aion.unity</groupId>
             <artifactId>pool-registry</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Add scope as "test" for pool-registry dependency as Pool registry classes are used only in test package of staker-registry. This is to avoid the packaging of pool-registry jar inside staker-registry during build.